### PR TITLE
Removed Comments and Changed Function names.

### DIFF
--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -267,7 +267,7 @@ void Player::HandleLoadResult(const UrlHandler::LoadResult &result) {
       qLog(Debug) << "URL handler for" << result.original_url_ << "said no more tracks";
 
       loading_async_ = QUrl();
-      NextItem(stream_change_type_);
+      PlayNextItem(stream_change_type_);
       break;
 
     case UrlHandler::LoadResult::TrackAvailable: {
@@ -332,11 +332,11 @@ void Player::NextInternal(Engine::TrackChangeFlags change) {
     }
   }
 
-  NextItem(change);
+  PlayNextItem(change);
 
 }
 
-void Player::NextItem(Engine::TrackChangeFlags change) {
+void Player::PlayNextItem(Engine::TrackChangeFlags change) {
 
   Playlist *active_playlist = app_->playlist_manager()->active();
 
@@ -772,7 +772,7 @@ void Player::InvalidSongRequested(const QUrl &url) {
     return;
   }
 
-  NextItem(Engine::Auto);
+  PlayNextItem(Engine::Auto);
 
 }
 

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -114,8 +114,7 @@ class PlayerInterface : public QObject {
   // Emitted when there's a manual change to the current's track position.
   void Seeked(qlonglong microseconds);
 
-  // Emitted when Player has processed a request to play another song.
-  // This contains the URL of the song and a flag saying whether it was able to play the song.
+
   void SongChangeRequestProcessed(const QUrl &url, bool valid);
 
   // The toggle parameter is true when user requests to toggle visibility for Pretty OSD
@@ -196,8 +195,8 @@ class Player : public PlayerInterface {
   void EngineMetadataReceived(const Engine::SimpleMetaBundle &bundle);
   void TrackAboutToEnd();
   void TrackEnded();
-  // Play the next item on the playlist - disregarding radio stations like last.fm that might have more tracks.
-  void NextItem(Engine::TrackChangeFlags change);
+
+  void PlayNextItem(Engine::TrackChangeFlags change);
   void PreviousItem(Engine::TrackChangeFlags change);
 
   void NextInternal(Engine::TrackChangeFlags);


### PR DESCRIPTION
After an in-depth and daring review of the main player.h file. I used a line-by-line investigation technique to identify any code-smells and pursue any needed refactoring that might be needed in order to increase the functionality and changeability of this file. In the file, after reviewing over 115 lines of code I found what I was looking for on the 117th line. Relying on my whits and my Delete and Backspaces keys I quickly removed these comments whose respective functions, upon reflection, had already indicated enough information for a layperson to understand in their very titles alone! The next issue came with another comment issue where the NextItem function had an entire comment devoted to explaining that the next item it was referring to was to be played. 
Well, that just won't do! I effectively used my experience from the first comments and scoured the program of this damnable dispensible, but not before I renamed all instances of the function to a more logical name, PlayNextItem. Surely the Strawberry music player is in my debt today.